### PR TITLE
CO-7031 CO-7043 : Adding retry logic for avoiding RequestLimitExceede…

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -1217,8 +1217,8 @@ module RightAws
     def initialize(right_aws_parser) 
       @right_aws_parser = right_aws_parser 
     end 
-    def on_characters(chars)
-      @right_aws_parser.text(chars) 
+    def on_characters(chars) 
+      @right_aws_parser.text(chars)
     end 
     def on_start_document; end 
     def on_comment(msg); end 

--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -513,7 +513,6 @@ module RightAws
           service_params = signed_service_params(@aws_secret_access_key, service_hash, http_verb, @params[:host_to_sign], @params[:service])
         end
       end
-
       # create a request
       case http_verb
       when 'GET'
@@ -525,7 +524,6 @@ module RightAws
       else
         raise "Unsupported HTTP verb #{verb.inspect}!"
       end
-
       # prepare output hash
       request_hash = { :request  => request,
                        :server   => @params[:server],

--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -1030,7 +1030,7 @@ module RightAws
     # 0-100 (%) 
     DEFAULT_CLOSE_ON_4XX_PROBABILITY = 10     
     
-    @@reiteration_start_delay = 2
+    @@reiteration_start_delay = 0.2
     def self.reiteration_start_delay
       @@reiteration_start_delay
     end
@@ -1038,7 +1038,7 @@ module RightAws
       @@reiteration_start_delay = reiteration_start_delay
     end
 
-    @@reiteration_time = 30
+    @@reiteration_time = 5
     def self.reiteration_time
       @@reiteration_time
     end

--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -586,8 +586,8 @@ module RightAws
             # Adding retry logic for avoiding RequestLimitExceeded exception and chef-cllient failures
             # before raising execption make sure currenct exception is not relateted to Ratelimiting and
             # also you are not exceeding limit if current exception if related to Ratelimiting
-            ratelimit_exception = e.message.match(/RequestLimitExceeded|RateExceeded/) ? true : false
-            raise e.message if ( !ratelimit_exception || retry_count >= 5 )
+            ratelimit_exception = e.include?(/RequestLimitExceeded/)
+            raise if ( !ratelimit_exception || retry_count >= 5 )
             puts "Retrying AWS API call because of Rate Limit Exceeded"
             retry_count += 1
             sleep retry_count * 3
@@ -631,8 +631,8 @@ module RightAws
             # Adding retry logic for avoiding RequestLimitExceeded exception and chef-cllient failures
             # before raising execption make sure currenct exception is not relateted to Ratelimiting and
             # also you are not exceeding limit if current exception if related to Ratelimiting
-            ratelimit_exception = e.message.match(/RequestLimitExceeded|RateExceeded/) ? true : false
-            raise e.message if ( !ratelimit_exception || retry_count >= 5 )
+            ratelimit_exception = e.include?(/RequestLimitExceeded/)
+            raise if ( !ratelimit_exception || retry_count >= 5 )
             puts "Retrying AWS API call because of Rate Limit Exceeded"
             retry_count += 1
             sleep retry_count * 3

--- a/lib/awsbase/version.rb
+++ b/lib/awsbase/version.rb
@@ -2,7 +2,7 @@ module RightAws #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 3  unless defined?(MAJOR)
     MINOR = 2  unless defined?(MINOR)
-    TINY  = 0  unless defined?(TINY)
+    TINY  = 1  unless defined?(TINY)
 
     STRING = [MAJOR, MINOR, TINY, 'coupa'].join('.') unless defined?(STRING)
   end


### PR DESCRIPTION
…d exception and chef-cllient failures

_Please add the appropriate [Risk Level label][1] and make sure you've followed the [code review guidelines][2]!_

## JIRA

_Complete the URLs for the main JIRA ticket and propagation subtask._

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CO-7031)
* [JIRA propagation subtask](https://coupadev.atlassian.net/browse/CO-7043)

## Code reviewers
- [ ] @nikhilcoupa 
- [ ] @marutinandanpandya 
- [ ] @alokdnb 
- [ ] @coupacooke 
- [ ] @charchitcoupa 
- [x] @abriel 
- [x] @autrejacoupa 

_Please list your code reviewers here. Use a [GitHub Task List][3] and [mention][4] the reviewers you want to review._

## Summary of issue

When ever we are doing snapshots or launch server we are getting RateLimitExceeded which causing chef-client workflow fail.

## Summary of change

Adding retried on RateLimitExceeded error from AWS.

## Testing approach

- [x] Please refer ticket for more details.

